### PR TITLE
Fix 11.0.0 pillow build

### DIFF
--- a/kivy_ios/recipes/pillow/__init__.py
+++ b/kivy_ios/recipes/pillow/__init__.py
@@ -5,8 +5,9 @@ import os
 
 
 class PillowRecipe(CythonRecipe):
-    version = "8.2.0"
-    url = "https://pypi.python.org/packages/source/P/Pillow/Pillow-{version}.tar.gz"
+    version = "11.0.0"
+    #url = "https://pypi.python.org/packages/source/p/pillow/pillow-{version}.tar.gz"
+    url = "https://github.com/python-pillow/Pillow/archive/refs/tags/{version}.tar.gz"
     library = "libpillow.a"
     depends = [
         "hostpython3",


### PR DESCRIPTION
The build for Pillow 11.0.0 doesn't work from this file without this change due to the original url scheme not working. Updated the pillow url to go to github to fetch the tar ball.